### PR TITLE
prevent inline openat

### DIFF
--- a/src/main/jni/openat.c
+++ b/src/main/jni/openat.c
@@ -9,6 +9,7 @@
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
+__attribute__((noinline))
 intptr_t openAt(intptr_t fd, const char *path, intptr_t flag) {
 #if defined(__arm__)
     intptr_t r;


### PR DESCRIPTION
without this hook check fails with ndk 25c 